### PR TITLE
Improve emote autocomplete keyboard navigation

### DIFF
--- a/src/injected-content/scss/_emotes.scss
+++ b/src/injected-content/scss/_emotes.scss
@@ -17,6 +17,7 @@
             padding: 0;
             margin: 0;
             display: inline-block;
+            vertical-align: middle;
             button {
                 width: auto;
                 display: flex;

--- a/src/injected-content/vue-apps/emote-autocomplete/emote-autocomplete-binder.js
+++ b/src/injected-content/vue-apps/emote-autocomplete/emote-autocomplete-binder.js
@@ -64,42 +64,40 @@ export function bindEmoteAutocompleteApp(globalEmotesCache, channelEmotesCache, 
 }
 
 function keydownListener(e) {
-    let child = app.$children[0] || {};
+    const child = app.$children[0] || {};
 
-    switch (e.which) {
-        case 37: //left
-        case 38: // up
-            if (child.showMenu) {
+    if (child.showMenu) {
+        switch (e.which) {
+            case 37: //left
                 child.decrementSelectedEmote();
                 e.preventDefault();
                 e.stopPropagation();
                 return false;
-            }
-            break;
-        case 39: // right
-        case 40: // down
-            if (child.showMenu) {
+            case 38: // up
+                child.decrementSelectedEmoteRow();
+                e.preventDefault();
+                e.stopPropagation();
+                return false;
+            case 39: // right
                 child.incrementSelectedEmote();
                 e.preventDefault();
                 e.stopPropagation();
                 return false;
-            }
-            break;
-        case 13: // enter
-            if (child.showMenu) {
+            case 40: // down
+                child.incrementSelectedEmoteRow();
+                e.preventDefault();
+                e.stopPropagation();
+                return false;
+            case 13: // enter
                 child.query = "";
-            }
-            break;
-        case 9: // tab
-            if (child.showMenu) {
+                break;
+            case 9: // tab
                 child.autocompleteSelectedEmote();
                 e.preventDefault();
                 e.stopPropagation();
                 e.stopImmediatePropagation();
                 return false;
-            }
-            break;
-
+        }
     }
 }
 

--- a/src/injected-content/vue-apps/emote-autocomplete/emote-autocomplete.vue
+++ b/src/injected-content/vue-apps/emote-autocomplete/emote-autocomplete.vue
@@ -46,13 +46,13 @@ export default {
     },
     methods: {
         getEmoteElementId: function(emote) {
-            return (emote.global ? "global-" : "channel-") + emote.name
+            return (emote.global ? "global-" : "channel-") + emote.name;
         },
         scrollSelectedIntoView: function() {
             let selectedEmote = this.filteredEmotes[this.selectedEmoteIndex];
             if(selectedEmote) {
                 const emoteElementId = this.getEmoteElementId(selectedEmote);
-                const element = document.getElementById(emoteElementId)
+                const element = document.getElementById(emoteElementId);
                 if(element) {
                     element.scrollIntoView(false);
                 }
@@ -72,6 +72,68 @@ export default {
             } else {
                 this.selectedEmoteIndex--;
             }
+            this.scrollSelectedIntoView();
+        },
+        computeRows: function() {
+            const rects = [...this.$el.getElementsByClassName('me-autocomplete-emote')].map(el => el.getBoundingClientRect());
+            const rows = [[]];
+            var currentRowHeight = Math.floor(rects[0].y);
+            for (let i = 0; i < rects.length; i++){
+                if (Math.floor(rects[i].y) == currentRowHeight){
+                    rows[rows.length - 1].push({index: i, pos: rects[i].x});
+                }
+                else{
+                    rows.push([]);
+                    currentRowHeight = Math.floor(rects[i].y);
+                    rows[rows.length - 1].push({index: i, pos: rects[i].x});
+                }
+            }
+            return rows;
+        },
+        incrementSelectedEmoteRow: function() {
+            const rows = this.computeRows();
+            
+            const currentRowIndex = rows.findIndex(row => row.find(posData => posData.index === this.selectedEmoteIndex));
+            let targetRowIndex;
+            if (currentRowIndex >= rows.length - 1) {
+                if (this.selectedEmoteIndex == this.filteredEmotes.length - 1) {
+                    this.selectedEmoteIndex = 0;
+                } else {
+                    this.selectedEmoteIndex = this.filteredEmotes.length - 1;
+                }
+                this.scrollSelectedIntoView();
+                return;
+            } else {
+                targetRowIndex = currentRowIndex + 1;
+            }
+
+            const currentPos = rows[currentRowIndex].find(posData => posData.index === this.selectedEmoteIndex).pos;
+            this.selectedEmoteIndex = rows[targetRowIndex]
+                .reduce((result, next) => Math.abs(currentPos - next.pos) < Math.abs(currentPos - result.pos) ? next : result).index;
+
+            this.scrollSelectedIntoView();
+        },
+        decrementSelectedEmoteRow: function() {
+            const rows = this.computeRows();
+
+            const currentRowIndex = rows.findIndex(row => row.find(posData => posData.index === this.selectedEmoteIndex));
+            let targetRowIndex;
+            if (currentRowIndex <= 0) {
+                if (this.selectedEmoteIndex == 0) {
+                    this.selectedEmoteIndex = this.filteredEmotes.length - 1;
+                } else {
+                    this.selectedEmoteIndex = 0;
+                }
+                this.scrollSelectedIntoView();
+                return;
+            } else {
+                targetRowIndex = currentRowIndex - 1;
+            }
+
+            const currentPos = rows[currentRowIndex].find(posData => posData.index === this.selectedEmoteIndex).pos;
+            this.selectedEmoteIndex = rows[targetRowIndex]
+                .reduce((result, next) => Math.abs(currentPos - next.pos) < Math.abs(currentPos - result.pos) ? next : result).index;
+
             this.scrollSelectedIntoView();
         },
         isSelected: function(index) {


### PR DESCRIPTION
#### Requirements

* Filling out the below template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

In the emote autocomplete menu, changes the up and down keys to behave similarly to in a text editor, where they go up and down rows.

Specifically, the up/down keys will go up/down a row, except if they are at the most extreme row in that direction, in which case they will go to either the first or last emote of that row (first for up, last for down). If they are already at their respective most extreme emote, they will go to the opposite extreme (e.g. pressing up at the first emote will send the selector to the last emote).

There is also a minor visual change to align emotes in the autocomplete menu into distinct rows. This is not noticeable unless you look for it, and the emotes not being in distinct rows was probably an unnoticed bug in the first place. This is a CSS change only, and not a DOM change.

### Benefits

This behavior is more intuitive than before and allows for easier access to desired emotes in the emote autocomplete menu.

### Possible Drawbacks

Calls getBoundingClientRect several times per up/down button press, which causes reflow and could hurt performance. However, there has been no visible performance hit of any kind in my testing.

### Applicable Issues

_None_

> Note:
> Please be aware that we may require changes (in code or in the UI) if we 
> believe they are required to meet the vision and standards of Elixr.
> Don't take suggestions for tweaks personally, we are all simply trying to make Elixr
> the best that it can be :)
