### PR TITLE
Fix costream rollout obstructing theatermode topbar

### DIFF
--- a/src/injected-content/scss/_theatermode.scss
+++ b/src/injected-content/scss/_theatermode.scss
@@ -110,4 +110,12 @@ b-channel-page-wrapper .stage:not(.aspect-16-9).me-video-stage{
     position: relative !important;
 }
 
+/* Co-Stream Theatermode top-bar fix*/
+.costream-rollout {
+	top: 59px !important;
+}
+
+.costream-rollout::before {
+	background: 0 !important;
+}
 /* End Theater Mode */

--- a/src/injected-content/scss/_theatermode.scss
+++ b/src/injected-content/scss/_theatermode.scss
@@ -111,11 +111,11 @@ b-channel-page-wrapper .stage:not(.aspect-16-9).me-video-stage{
 }
 
 /* Co-Stream Theatermode top-bar fix*/
-.costream-rollout {
+.stage.theaterMode .costream-rollout {
 	top: 59px !important;
 }
 
-.costream-rollout::before {
-	background: 0 !important;
+.stage.theaterMode .costream-rollout::before {
+	background: rgba(0, 0, 0, 0.25) !important;
 }
 /* End Theater Mode */


### PR DESCRIPTION
Fix costream rollout obstructing theatermode topbar ** Thanks Ebiggz for the complete guidance on this! Tested on Chrome and Firefox, seems to be working fine

#### Requirements
### Description of the Change
Broken
![image](https://user-images.githubusercontent.com/23622992/68183703-0357d600-ff52-11e9-8b10-9a8008e65f01.png)


Fixed
![image](https://user-images.githubusercontent.com/23622992/68183615-c095fe00-ff51-11e9-9a20-09774eab8b16.png)

![image](https://user-images.githubusercontent.com/23622992/68183626-cb509300-ff51-11e9-8f7a-e43990e0d662.png)

### Benefits

Many of them : ). Like topbar access

### Possible Drawbacks


### Applicable Issues
