### PR TITLE
Adjust how emote replacements works to better improve extension compatibility

### DIFF
--- a/src/injected-content/mixrelixr.js
+++ b/src/injected-content/mixrelixr.js
@@ -1407,7 +1407,7 @@ $(() => {
                 messageContainer.find('span:not([class])').each(function() {
                     let component = $(this);
                     // we've already replaced emotes on this, skip it
-                    if (component.hasClass('me-custom-emote')) {
+                    if (component.attr('me-custom-emote')) {
                         return;
                     }
 
@@ -1504,6 +1504,13 @@ $(() => {
                         component.html(text.trim());
 
                         component
+                            .contents()
+                            .filter(function() {
+                                return this.nodeType === 3;
+                            })
+                            .wrap('<span></span>');
+
+                        component
                             .find('.elixr-custom-emote')
                             .children('img')
                             .on('load', function() {
@@ -1523,7 +1530,7 @@ $(() => {
                             });
 
                         // tag this component so we dont attempt to look for emotes again
-                        component.addClass('me-custom-emote');
+                        component.attr('me-custom-emote', '');
                     }
                 });
             }

--- a/src/injected-content/mixrelixr.js
+++ b/src/injected-content/mixrelixr.js
@@ -1407,7 +1407,7 @@ $(() => {
                 messageContainer.find('span:not([class])').each(function() {
                     let component = $(this);
                     // we've already replaced emotes on this, skip it
-                    if (component.attr('me-custom-emote')) {
+                    if (component.hasClass('me-custom-emote')) {
                         return;
                     }
 
@@ -1530,7 +1530,7 @@ $(() => {
                             });
 
                         // tag this component so we dont attempt to look for emotes again
-                        component.attr('me-custom-emote', '');
+                        component.addClass('me-custom-emote');
                     }
                 });
             }


### PR DESCRIPTION
### Description of the Change
<!-- We must be able to understand the design of your change from this description. -->

Wraps `Text` nodes in class-less `span`s after emote replacement for compatibility.

### Benefits
<!-- What benefits will be realized by the code change? -->

This change allows other extensions to parse chat messages more reliably by allowing the use of the `span:not([class])` selector to find replaceable text, which Elixr also uses.

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->
None.

### Applicable Issues
<!-- Enter any applicable Issues (link them or reference their ID) here -->
No issues from MixrElixr, but this issue from Better Mixer discusses the issue:
https://github.com/TheUnlocked/Better-Mixer/issues/55

> Note:
> Please be aware that we may require changes if we 
> believe they are required to meet the vision and standards of Elixr.
> Don't take suggestions for tweaks personally, we are all simply trying to make Elixr
> the best that it can be :)