### PR TITLE
Hotfixing Skills menu when in Theatermode

### DIFF
--- a/src/injected-content/scss/_theatermode.scss
+++ b/src/injected-content/scss/_theatermode.scss
@@ -116,6 +116,7 @@ b-nav-host > div.theaterMode {
 .channel-info-container.theaterMode .skills-tray-container {
     top: 84px !important;
     bottom: 0 !important;
+    transform: translateY(95%) !important;
 }
 
 


### PR DESCRIPTION
Hotfixing Skillsmenu being obstructed by top bar when in theatermode. 

### Description of the Change
Fixes this issue
![image](https://user-images.githubusercontent.com/23622992/73700957-ee97f500-469c-11ea-93dc-408e9dc91095.png)

Now shows below, once again
![image](https://user-images.githubusercontent.com/23622992/73700963-f35ca900-469c-11ea-8654-0610eaa6f2ce.png)

### Benefits
Works on 1920 x 1080p (My res) , 1920 x 1200 (Perry's res), 4k (emulated), 1366 x 768 (emulated), and 1600 x 900 (emulated in responsive design via dev tools)

- Tested and working on both Chrome and Firefox

### Credit
Thanks to Perry for helping me test it and teaching me basic git to make this pr clean