### PR TITLE
Alt + T shortcut to toggle theatermode

### DIFF
--- a/src/injected-content/mixrelixr.js
+++ b/src/injected-content/mixrelixr.js
@@ -932,7 +932,7 @@ $(() => {
                 theaterBtn.find('i').text('event_seat');
 
                 // change tooltip text
-                theaterBtn.find('span').text('MixrElixr: Theater Mode');
+                theaterBtn.find('span').text('MixrElixr: Theater Mode (Alt + T)');
 
                 // add click handler
                 theaterBtn.on('click', function() {
@@ -1048,7 +1048,7 @@ $(() => {
                         heading: 'Theater Mode Enabled',
                         showHideTransition: 'fade',
                         allowToastClose: true,
-                        hideAfter: 3000,
+                        hideAfter: 3250,
                         stack: false,
                         position: 'top-center',
                         bgColor: '#151C29',
@@ -2219,6 +2219,13 @@ $(() => {
             if (theaterModeEnabled()) {
                 toggleTheaterMode();
             }
+        }
+    });
+
+    // Alt + T theater toggle keycombo listener
+    $(document).keydown(function(t) {
+        if (t.code === 'KeyT' && t.altKey) {
+            toggleTheaterMode();
         }
     });
 


### PR DESCRIPTION
Alt + T key combo now toggles theater mode on and off! Escape still works too separately to exit theatermode

### Description of the Change
<!-- We must be able to understand the design of your change from this description. -->
Repurposed the escape event listener code to create a key combination of Alt + T that toggles theatermode on and off! 

- Updated tooltip 
![image](https://user-images.githubusercontent.com/23622992/73704939-6f5cee00-46a9-11ea-803a-2eb7ef9cb7a8.png)

- Slowed down this toast by 1/4 of a second for slower readers, feel free to revert this
![image](https://user-images.githubusercontent.com/23622992/73705024-961b2480-46a9-11ea-8550-d9122bbbb229.png)

### Benefits
<!-- What benefits will be realized by the code change? -->

- Ease of access shortcut keys, sometimes I want to exit the theater mode to look at vods/clips, but am too lazy to click the theatermode button again. 

### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the code change? -->
I admit I have no idea how this will function on MacOs. I used this https://www.w3.org/TR/uievents-code/#keyboard-key-codes . I assume alt/option + T on mac may still do the same thing?

### Credit
SReject helped me remove redundant code before this commit, thanks Reject!